### PR TITLE
Use multi_route plugin in roda's tests

### DIFF
--- a/apps/roda/config.ru
+++ b/apps/roda/config.ru
@@ -1,12 +1,19 @@
 require 'roda'
 
 class App < Roda
-  route do |r|
-    ENV['EDA'].to_i.times do |index|
-      r.get(index.to_s) do
+  plugin :multi_route
+
+  ENV['EDA'].to_i.times do |index|
+    i = index.to_s
+    route(i) do |r|
+      r.get true do
         'Hello World'
       end
     end
+  end
+  
+  route do |r|
+    r.multi_route
 
     r.root do
       'Hello Roda!'


### PR DESCRIPTION
The way the test was written before, routing was O(n) where n was
the number of routes.  This ignores the flexible nature of roda's
routing, and makes roda's performance look much worse than it is
in practice.

This uses roda's multi_route plugin (which ships with roda) to
split the routing tree into separate routing trees, which should
more accurately reflect roda's real world performance.

Roda's documentation specifically encourages using the multi_route
plugin in this manner for large applications:
http://roda.jeremyevans.net/rdoc/files/doc/conventions_rdoc.html