### PR TITLE
Actually use multi_route in Roda's tests

### DIFF
--- a/apps/roda/config.ru
+++ b/apps/roda/config.ru
@@ -1,20 +1,21 @@
 require 'roda'
 
 Roda.plugin(:multi_route)
+
+ENV['EDA'].to_i.times do |index|
+  i = index.to_s
+  Roda.route(i) do |r|
+    r.get true do
+      'Hello World'
+    end
+  end
+end
+
 Roda.route do |r|
   r.multi_route
-  r.get do
 
-    ENV['EDA'].to_i.times do |index|
-      r.is(index.to_s) do
-        index.to_s
-      end
-    end
-
-    r.root do
-      'Hello Roda!'
-    end
-
+  r.root do
+    'Hello Roda!'
   end
 end
 


### PR DESCRIPTION
Pull Request #1 fixed this, but then it was changed back to using
a linear lookup in b516158b43ee197a5d71df7ac92a21f0b9122907

This fixes the Roda tests to actually use multi_route again, while
keeping other changes made (no App, just Roda, and using freeze).

With this commit, Roda is always faster than rack-app, 1.25x-2.6x
depending on the test.  If you make changes to the Roda app and
the tests start showing it as slower than many other frameworks,
you've probably reintroduced linear behavior.
